### PR TITLE
fix: bump strict_minimum_version of firefox

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "chatterino_native@chatterino.com",
-      "strict_min_version": "50.0"
+      "strict_min_version": "109.0"
     }
   },
   "manifest_version": 3,


### PR DESCRIPTION
Manifest v3 is only supported in Firefox >= 109 so we need to set that as the minimum version.